### PR TITLE
Don't rely on transparent global access to React, Relay, ReactDOM

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1,5 +1,10 @@
+import 'babel/polyfill';
+
 import App from './components/App';
 import AppHomeRoute from './routes/AppHomeRoute';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import Relay from 'react-relay';
 
 ReactDOM.render(
   <Relay.RootContainer

--- a/js/components/App.js
+++ b/js/components/App.js
@@ -1,4 +1,5 @@
-import 'babel/polyfill';
+import React from 'react';
+import Relay from 'react-relay';
 
 class App extends React.Component {
   render() {

--- a/js/routes/AppHomeRoute.js
+++ b/js/routes/AppHomeRoute.js
@@ -1,3 +1,5 @@
+import Relay from 'react-relay';
+
 export default class extends Relay.Route {
   static queries = {
     viewer: () => Relay.QL`

--- a/public/index.html
+++ b/public/index.html
@@ -11,20 +11,8 @@
       // Force `fetch` polyfill to workaround Chrome not displaying request body
       // in developer tools for the native `fetch`.
       self.fetch = null;
-      function warnRelayMissing() {
-        document.body.innerHTML = (
-          '<h2>Could not find relay.js</h2>' +
-          '<p>' +
-            'Be sure to run <code>npm run build</code> ' +
-            'in the <code>relay/</code> directory.' +
-          '</p>'
-        );
-      }
     </script>
     <script src="http://localhost:3000/webpack-dev-server.js"></script>
-    <script src="react/react.min.js"></script>
-    <script src="react/react-dom.min.js"></script>
-    <script src="relay/relay.js" onerror="warnRelayMissing()"></script>
     <script src="js/app.js"></script>
   </body>
 </html>

--- a/server.js
+++ b/server.js
@@ -21,9 +21,10 @@ var compiler = webpack({
   module: {
     loaders: [
       {
-        test: /\.js$/,
+        exclude: /node_modules/,
         loader: 'babel',
-        query: {stage: 0, plugins: ['./build/babelRelayPlugin']}
+        query: {stage: 0, plugins: ['./build/babelRelayPlugin']},
+        test: /\.js$/,
       }
     ]
   },

--- a/server.js
+++ b/server.js
@@ -37,14 +37,6 @@ var app = new WebpackDevServer(compiler, {
 });
 // Serve static resources
 app.use('/', express.static(path.resolve(__dirname, 'public')));
-app.use(
-  '/react',
-  express.static(path.resolve(__dirname, 'node_modules/react/dist'))
-);
-app.use(
-  '/relay',
-  express.static(path.resolve(__dirname, 'node_modules/react-relay/dist'))
-);
 app.listen(APP_PORT, () => {
   console.log(`App is now running on http://localhost:${APP_PORT}`);
 });


### PR DESCRIPTION
This was originally raised here:

- https://github.com/relayjs/relay-starter-kit/issues/34

as a smell, but it has also come up on Stack Overflow:

- http://stackoverflow.com/questions/32708927/how-do-you-move-from-stock-relay-to-relay-with-a-router

I ran into the same issues while adding react-router-relay to a project
that previously just included the built bundles via `<script>` tags,
like the starter kit does:

- https://github.com/relay-tools/react-router-relay/issues/35
- https://github.com/relay-tools/react-router-relay/issues/49

I think avoiding possible confusion here makes it worth making the
change and switching to explicit `import` statements, which is what this
commit does.

Test Plan: `npm run start` and hit http://localhost:3000; see widget
list.